### PR TITLE
Make Buffer work in the browser

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -1,8 +1,6 @@
 //========================================================================================
 // Globals
 //========================================================================================
-var vm = require("vm");
-
 var Context = require("./context").Context;
 var Long = require('long');
 
@@ -325,7 +323,7 @@ Parser.prototype.resolveReferences = function(ctx) {
 
 Parser.prototype.compile = function() {
   var src = "(function(buffer, constructorFn, Long) { " + this.getCode() + " })";
-  this.compiled = vm.runInThisContext(src);
+  this.compiled = eval(src);
 };
 
 Parser.prototype.sizeOf = function() {


### PR DESCRIPTION
@cmdcolin, I'm not sure if this is the best way to do it, but this does fix the "Buffer is not defined" error you were getting with your sequence track. FWIW, vm-browserify just uses `eval` for `runInThisContext` anyway.