### PR TITLE
feat: add browser alias for nodejs builtin 'vm'

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "build": "babel lib -d dist",
     "test-webpack": "webpack --config test/browser/webpack.config.js && node test/browser/run-puppeteer.js"
   },
+  "browser": {
+    "vm": "./vm-browser.js"
+  },
   "keywords": [
     "binary",
     "parser",

--- a/vm-browser.js
+++ b/vm-browser.js
@@ -1,0 +1,7 @@
+// https://github.com/ionic-team/rollup-plugin-node-polyfills/blob/9b5fe1a9cafffd4871e6d65613ed224f807ea251/polyfills/vm.js#L129-L132
+function runInThisContext(code) {
+  const fn = new Function('code', 'return eval(code);');
+  return fn.call(globalThis, code);
+}
+
+module.exports.runInThisContext = runInThisContext;


### PR DESCRIPTION
Thank you for your work on this library! Webpack [removed automatic nodejs polyfills](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed) in version 5, and other modern bundlers (rollup, esbuild, vite) do not automatically polyfill. This PR adds a ["browser" field](https://gist.github.com/defunctzombie/4339901) to the `package.json` which tells bundlers how to resolve the module for a browser target. Since only `vm.runInThisContext` is used, the browser polyfill is very minimal.

If you run `yarn test-webpack`, you'll see that webpack resolves `vm` to `./vm-browser.js` and that module is included in `bundle.js`.